### PR TITLE
enable proxy for HttpClient

### DIFF
--- a/src/main/java/cmanager/network/ApacheHttp.java
+++ b/src/main/java/cmanager/network/ApacheHttp.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -14,10 +15,21 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 
 public class ApacheHttp {
 
-    private final CloseableHttpClient httpClient = HttpClients.createDefault();
+    private final CloseableHttpClient httpClient;
+    
+    public ApacheHttp() {
+        if (System.getProperty("https.proxyHost") != null) {
+            HttpHost httpsProxy = new HttpHost(System.getProperty("https.proxyHost"), Integer.parseInt(System.getProperty("https.proxyPort")));
+            DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(httpsProxy);
+            httpClient = HttpClients.custom().setRoutePlanner(routePlanner).build();
+        } else {
+            httpClient = HttpClients.createDefault();
+        }
+    }
 
     public static class HttpResponse {
 


### PR DESCRIPTION
Den HttpClient ermöglichen einen Proxy zu nutzen, wenn das Programm in einem geschützten Netzwerk ausgeführt wird. Der Proxy wird aus den Java-Parametern ausgelesen (-DhttpsProxyHost=... -DhttpsProxyPort=...)