### PR TITLE
Remove Gradle deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,6 @@ task Version(type: Copy) {
     into 'src/main/java/cmanager/global'
 }
 
-verifyGoogleJavaFormat.dependsOn OcOkapiKeys, Version
 compileJava.dependsOn OcOkapiKeys, Version
 compileTestJava.dependsOn OcTestClientLogin
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,22 +49,27 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
 
     // Use the JUnit testing framework.
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.3'
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.3'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.3'
+    testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.9.3'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
 }
 
-// Define the main class for the application.
-mainClassName = 'cmanager.Main'
+application {
+    // Define the main class for the application.
+    mainClass = 'cmanager.Main'
+}
 
 project.ext.ocOkapiPropertiesFile = projectDir.getPath() + "${File.separator}oc_okapi.properties"
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 version = '0.7.0'
 
 wrapper {
-    gradleVersion = '8.1.1'
+    gradleVersion = '8.2.1'
 }
 
 // Use JUnit 5 for testing.
@@ -116,6 +121,7 @@ task Version(type: Copy) {
     into 'src/main/java/cmanager/global'
 }
 
+verifyGoogleJavaFormat.dependsOn OcOkapiKeys, Version
 compileJava.dependsOn OcOkapiKeys, Version
 compileTestJava.dependsOn OcTestClientLogin
 
@@ -131,7 +137,7 @@ jar {
         archiveVersion = 'ci'
     }
     manifest {
-        attributes 'Main-Class': mainClassName
+        attributes 'Main-Class': application.mainClass
     }
     duplicatesStrategy = DuplicatesStrategy.INCLUDE  // Allow duplicates.
 


### PR DESCRIPTION
This should pave the way for Gradle 9.x (when it releases eventually) by migrating away from all deprecations